### PR TITLE
Fix default level bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Splunk logging for Ruby
 
+## Version 0.0.3
+* Fixed a bug that was causing the default level to not be set to info if no paramater is provided when creating the 
+client
+
 ## Version 0.0.2
 * Add trigger to send logs when max_batch_size is met
 * Added thread protection to prevent multiple threads from sending simultaneously

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    splunk_logger (0.0.2)
+    splunk_logger (0.0.3)
       faraday (~> 0.9, >= 0.9)
       faraday_middleware (~> 0, >= 0)
 

--- a/lib/splunk_logger/client.rb
+++ b/lib/splunk_logger/client.rb
@@ -13,7 +13,7 @@ module SplunkLogger
       token = options[:token]
       url = options[:url]
       verify_ssl = options[:verify_ssl].nil? ? true : options[:verify_ssl]
-      @default_level = options[:default_level].to_s || 'info'
+      @default_level = options[:default_level] || 'info'
       @send_interval = options[:send_interval].to_i
       @max_batch_size = (options[:max_batch_size] || 100).to_i
       @max_queue_size = (options[:max_queue_size] || 10000).to_i

--- a/lib/splunk_logger/version.rb
+++ b/lib/splunk_logger/version.rb
@@ -1,3 +1,3 @@
 module SplunkLogger
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end


### PR DESCRIPTION
Fixes a bug where default level is a empty string instead of info when
crating a client with no default_level provided.